### PR TITLE
fix package name underscore

### DIFF
--- a/summon_python/tasks.py
+++ b/summon_python/tasks.py
@@ -67,14 +67,16 @@ def format(  # pylint: disable=redefined-builtin
     If files is omitted. everything is linted.
     """
 
-    check_flag = ['--check'] if check else []
+    check_flag = ['--check'] if check else ['-q']
 
     subject = args_or_all_modules(files)
 
     if not subject:
         return []
 
-    args = ['-q', *check_flag, *subject]
+    quiet_flag = ['-q'] if not check else []
+
+    args = [quiet_flag, *check_flag, *subject]
 
     return [
         execute(['black', *args], raise_error=False),


### PR DESCRIPTION
- Replace - for _ when reading package name from pyproject.toml. Update poetry.lock.
- format: Do not pass quiet flag if checking.
