### PR TITLE
format: Do not pass quiet flag if checking.

### DIFF
--- a/summon_python/tasks.py
+++ b/summon_python/tasks.py
@@ -74,7 +74,9 @@ def format(  # pylint: disable=redefined-builtin
     if not subject:
         return []
 
-    args = ['-q', *check_flag, *subject]
+    quiet_flag = ['-q'] if not check else []
+
+    args = [*quiet_flag, *check_flag, *subject]
 
     return [
         execute(['black', *args], raise_error=False),


### PR DESCRIPTION
When using `--check`, no output is given due to `-q`. I would expect `--check` to report what made it fail, e.g. which files aren't formatted.